### PR TITLE
Serve plugin via ovos-tts-server docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+TODO.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Google Translate's free TTS endpoint (gTTS) served through ovos-tts-server's
+# ElevenLabs-compatible API. A self-contained image: any client that speaks the
+# ovos-tts-server / ElevenLabs API can hit it, and it can be A/B-tested against other
+# ovos-tts-server voices (edge-tts, phoonnx, ...) by pointing at a different port.
+#
+# gTTS calls translate.google.com to synthesize speech, so this container needs
+# network access (it is not an offline/air-gapped voice). No API key is required.
+FROM python:3.11-slim
+
+# ffmpeg: gTTS emits mp3; ovos-tts-server transcodes non-WAV plugin output to WAV.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+# the plugin + the OVOS TTS server. setuptools<81 keeps ovos-plugin-manager's
+# pkg_resources usage working. ovos-tts-server>=1.13.5a1 carries the non-WAV transcode
+# fix (gTTS emits mp3); the alpha floor lets pip resolve the prerelease without --pre.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<81" "." "ovos-tts-server>=1.13.5a1"
+
+# Default language, overridable with the GTTS_LANG build arg (any gTTS lang works).
+ARG GTTS_LANG=en
+RUN useradd -m -u 1000 ovos \
+    && mkdir -p /home/ovos/.config/mycroft \
+    && printf '{\n  "tts": {\n    "module": "ovos-tts-plugin-google-tx",\n    "ovos-tts-plugin-google-tx": {\n      "lang": "%s"\n    }\n  }\n}\n' "${GTTS_LANG}" \
+        > /home/ovos/.config/mycroft/mycroft.conf \
+    && chown -R 1000:1000 /home/ovos/.config
+USER 1000
+
+EXPOSE 9666
+ENTRYPOINT ["ovos-tts-server", "--engine", "ovos-tts-plugin-google-tx", \
+            "--host", "0.0.0.0", "--port", "9666", "--cache"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ It can stop working at any time and should never be used in production or commer
 
 `pip install ovos-tts-plugin-google-tx`
 
+## Docker
+
+A prebuilt image serves this plugin behind [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)
+(an ElevenLabs-compatible HTTP API) on port `9666`:
+
+```bash
+docker run -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-google-tx:dev
+```
+
+or with compose:
+
+```bash
+docker compose up
+```
+
+The served language defaults to `en` and is set via the `GTTS_LANG` build arg:
+
+```bash
+docker build --build-arg GTTS_LANG=fr -t google-tx-tts .
+```
+
+The image is self-contained and needs **no API key**, but it does need **network
+access at runtime**: gTTS synthesizes speech by calling `translate.google.com`, so the
+container is not an offline/air-gapped voice.
+
 ## Configuration
 
 ```json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  google-tx-tts:
+    image: ghcr.io/openvoiceos/ovos-tts-plugin-google-tx:latest
+    # …or build locally: build: .
+    container_name: google-tx-tts
+    restart: unless-stopped
+    ports:
+      - "9666:9666"
+    # optional: override the served language
+    # environment: {}  # (lang is a build arg; rebuild with --build-arg GTTS_LANG=fr)
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9666/status')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
Adds a self-contained container that serves this plugin behind `ovos-tts-server`'s ElevenLabs-compatible API on port 9666, published to `ghcr.io/openvoiceos/ovos-tts-plugin-google-tx` from CI.

## What's included
- `Dockerfile` — `python:3.11-slim`, installs the plugin + `ovos-tts-server>=1.13.5a1`; `ffmpeg` apt dep for the mp3 to WAV transcode (gTTS emits mp3). Default `GTTS_LANG=en` build arg, non-root user.
- `.dockerignore`, `docker-compose.yml`
- `.github/workflows/docker.yml` — build on PR, build+push on dev/master/tags.
- README Docker section.

## Runtime caveat
No API key needed, but the container needs network access at runtime: gTTS calls `translate.google.com`. Not an offline voice.